### PR TITLE
UserQueue widget fixes

### DIFF
--- a/UserQueue/widget.js
+++ b/UserQueue/widget.js
@@ -77,7 +77,7 @@ window.addEventListener('onEventReceived', function (obj) {
         return;
     }
     // Broadcaster commands only below
-    if (user !== channel) return;
+    if (user.toLowerCase() !== channel) return;
     if (message.indexOf(drawCommand) === 0) {
         message = message.split(" ");
         drawFromQueue(message[1]);

--- a/UserQueue/widget.js
+++ b/UserQueue/widget.js
@@ -64,7 +64,7 @@ window.addEventListener('onWidgetLoad', function (obj) {
 window.addEventListener('onEventReceived', function (obj) {
     if (obj.detail.listener !== "message") return;
     let data = obj.detail.event.data;
-    let message = html_encode(["text"]);
+    let message = html_encode(data["text"]);
     let user = data["displayName"];
     if (message.indexOf(queueCommand) === 0) {
         message = message.split(" ");

--- a/UserQueue/widget.js
+++ b/UserQueue/widget.js
@@ -40,8 +40,8 @@ function loadState() {
     SE_API.store.get('userQueue').then(obj => {
 
         if (obj !== null) {
-            users = data[0];
-            nicknames = data[1];
+            users = obj[0];
+            nicknames = obj[1];
         } else SE_API.store.set('userQueue', [users, nicknames])
     });
 

--- a/UserQueue/widget.js
+++ b/UserQueue/widget.js
@@ -88,7 +88,7 @@ window.addEventListener('onEventReceived', function (obj) {
         return;
     }
     if (message === purgeCommand) {
-        clearScreen();
+        purge();
         return;
     }
 


### PR DESCRIPTION
### Summary
Minor fixes to the UserQueue widget.

---

**Fixed not referencing message text correctly**
Resolves `TypeError: e.replace is not a function` when message is sent in chat.

**Fixed not loading from SE native kvstore correctly**
Resolves `ReferenceError: data is not defined` when widget is loaded.

**Fixed not purging queue on command**
Resolves queue not re-instantiating when using `!purge` command.

**Fixed capitalisation comparison between usernames**
Resolves an issue where channel name maybe have capital letters but `onWidgetLoad` > `obj.detail.channel.username` is lowercase, therefore broadcaster commands do not work.
