### PR TITLE
[FIX] Include missing events in skippable array

### DIFF
--- a/CustomCode.md
+++ b/CustomCode.md
@@ -708,7 +708,7 @@ Code:
 ```
 ##### JS:
 ```js
-let skippable=["bot:counter","event:test","event:skip","message","kvstore:update"]; //Array of events coming to widget that are not queued so they can come even queue is on hold
+let skippable=["bot:counter","event","event:test","event:skip","alertService:toggleSound","message","delete-message","delete-messages","kvstore:update"]; //Array of events coming to widget that are not queued so they can come even queue is on hold
 let playAnimation=(event)=>{
     $("container").html(`<div id="sender">${event.sender}</div><div class="amount">${event.amount} subs!</div>`)
     return Math.floor(Math.random()*8)+7;


### PR DESCRIPTION
This PR adds some events that should be included in the skippable array, as they don't add widgets to the queue (#28):

- `"event"`: received with every real event (i.e. the equivalent in production of `"event:test"`)
- `"alertService:toggleSound"`: received when alerts are muted/unmuted in the Activity Feed or within the editor
- `"delete-message","delete-messages"`: received when chat messages are deleted

Published widgets that use the skippable list should be updated too, but I'd rather leave that to widget owners/repo maintainers