### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/CustomChat/widget.js
+++ b/CustomChat/widget.js
@@ -97,7 +97,7 @@ window.addEventListener('onEventReceived', function (obj) {
     }
     let username = data.displayName + ":";
     if (nickColor === "user") {
-        const color = data.displayColor !== "" ? data.displayColor : "#" + (md5(username).substr(26));
+        const color = data.displayColor !== "" ? data.displayColor : "#" + (md5(username).slice(26));
         username = `<span style="color:${color}">${username}</span>`;
     }
     else if (nickColor === "custom") {

--- a/InstaPhoto/widget.js
+++ b/InstaPhoto/widget.js
@@ -139,7 +139,7 @@ async function instaDataByUser(username) {
             console.error("Instagram Error: It seems that the profile you are trying to recover has age restrictions");
             return;
         }
-        data = JSON.parse(data.substr(0, data.length - 1));
+        data = JSON.parse(data.slice(0, -1));
         data = data.entry_data.ProfilePage;
         if (typeof data === "undefined") {
             console.error(


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None
