### PR TITLE
`widget-button` doesn't exist in `obj.detail.listener`

### DIFF
--- a/docs/CustomWidgetEvents.md
+++ b/docs/CustomWidgetEvents.md
@@ -307,7 +307,6 @@ In the example above you have obj forwarded to that function, which has two inte
     * `alertService:toggleSound` - User clicked "mute/unmute alerts" button in activity feed
     * `bot:counter` - Update of bot counter
     * `kvstore:update` - Update of [SE_API](#se-api) store value.
-    * `widget-button` - User clicked custom field button in widget properties
 
 * `obj.detail.event`: Will provide you information about event details. It contains few keys. For `-latest` events it is:
     * `.name` - user who triggered action


### PR DESCRIPTION
The user thekillgfx (on SE Discord) found the widget documentation is wrong where it shows the `widget-button` value here: https://dev.streamelements.com/docs/widgets/6707a030af0b9-custom-widget-events#on-event

Documentation says the value can be found in `obj.detail.listener`, but it is actually found in `obj.detail.event.listener`, which is correctly shown in the code example: https://dev.streamelements.com/docs/widgets/6707a030af0b9-custom-widget-events#button-click

My suggestion: Just remove the `widget-button` line from `obj.detail.listener` docuementation as you already have a working example of it on the same page.